### PR TITLE
Specify `skia_gl_standard` to `gles` during build by default and allow users a way to build for a different standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ skia-builder setup-env --sub-env=Android
 
 skia-builder build --sub-env=Android --target-cpu=arm --custom-build-args="extra_cflags=['-g0'] is_debug=false is_component_build=false cc='clang' cxx='clang++' extra_cflags_cc=['-std=c++17'] ..."
 ```
+
+For macOS, we assume the built library will be used in an application that uses ANGLE as a GL provider. As a result, we force the `skia_gl_standard` setting to `"gles"`, since Skia cannot accurately detect the OpenGL version when running with ANGLE on macOS.
+
+If you intend to use Skia in an environment that does not rely on GLES (e.g., standard macOS OpenGL), you can override this default by setting the `SKIABUILDER_SKIA_GL_STANDARD` environment variable. This lets you specify a different value for the `skia_gl_standard` argument, such as `"gl"` (for default macOS OpenGL).

--- a/builder/config.py
+++ b/builder/config.py
@@ -88,6 +88,9 @@ macos_base_flags = {
     "skia_use_metal": True,
     # build env configs
     "target_os": "mac",
+    "skia_gl_standard": os.environ.get(
+        "SKIABUILDER_SKIA_GL_STANDARD", "gles"
+    ),
 }
 
 platform_specific_flags = {


### PR DESCRIPTION
`GrGLGetStandardInUseFromString` which is called during interface validity checks, does not correctly recognize the version string reported by ANGLE on macOS (`OpenGL ES 3.0.0 (ANGLE 2.1.24078 git hash: ac6cda4cbd71)`) therefore fallbacks to `gl` as the standard to be used.

From Skia code looks like OpenGL ES 3.x.x is not handled as a valid version, even if it should be, as is compatible with OpenGL ES 2.x.x.

Even if we (Kivy) set the context to be created with version 2.x.x, the reported version is still 3.x.x.

Will open a bug on Skia issue tracker.

