### PR TITLE
Fix environment setup for iOS / iOS Simulator

### DIFF
--- a/skia_builder/platforms/ios.py
+++ b/skia_builder/platforms/ios.py
@@ -1,11 +1,16 @@
 from skia_builder.platforms.common import CommonSubPlatformManager, SubPlatform
+from skia_builder.platforms.macos import MacOSPlatformManager
 
 
 class IOSPlatformManager(CommonSubPlatformManager):
+    @staticmethod
+    def _setup_env_host_macos(skip_llvm_instalation):
+        MacOSPlatformManager.setup_env(skip_llvm_instalation)
+
     HOST_PLATFORMS_ENV_SETUP = {
         "Linux": None,
         "Windows": None,
-        "macOS": CommonSubPlatformManager.noop,
+        "macOS": _setup_env_host_macos,
     }
     TARGET_PLATFORM = SubPlatform.IOS
     HOST_PLATFORM = TARGET_PLATFORM.host_platform

--- a/skia_builder/platforms/iossimulator.py
+++ b/skia_builder/platforms/iossimulator.py
@@ -1,11 +1,16 @@
 from skia_builder.platforms.common import CommonSubPlatformManager, SubPlatform
+from skia_builder.platforms.macos import MacOSPlatformManager
 
 
 class IOSSimulatorPlatformManager(CommonSubPlatformManager):
+    @staticmethod
+    def _setup_env_host_macos(skip_llvm_instalation):
+        MacOSPlatformManager.setup_env(skip_llvm_instalation)
+
     HOST_PLATFORMS_ENV_SETUP = {
         "Linux": None,
         "Windows": None,
-        "macOS": CommonSubPlatformManager.noop,
+        "macOS": _setup_env_host_macos,
     }
     TARGET_PLATFORM = SubPlatform.IOS_SIMULATOR
     HOST_PLATFORM = TARGET_PLATFORM.host_platform


### PR DESCRIPTION
## Description

After the changes made [here ](https://github.com/DexerBR/skia-builder/pull/12) the workflow for iOS / iOS Simulator started to fail, due to the lack of a handler to configure the host environment on macOS. This PR fixes that.

## Checklist

- [x] Code passes `ruff check .`
- [x] Code is formatted with `ruff format`
