### PR TITLE
Disable `skia_enable_pdf` and `use_expat` for iOS builds

### DIFF
--- a/skia_builder/config.py
+++ b/skia_builder/config.py
@@ -108,6 +108,8 @@ ios_base_flags = {
     # build env configs
     "target_os": "ios",
     "ios_min_target": "13.0",
+    "skia_enable_pdf": False,
+    "skia_use_expat": False,
 }
 
 platform_specific_flags = {


### PR DESCRIPTION
## Description

As suggested in Skia Skottie example for iOS, disable `skia_enable_pdf` and `use_expat` as these flags create duplicate symbols in static libraries (keeping track of the issue on Skia side).

ATM pdf features are not needed (on any platform) and `use_expat` should be really required only for Android.

## Checklist

- [x] Code passes `ruff check .`
- [x] Code is formatted with `ruff format`
