### PR TITLE
Fix Skia linking error on Linux x64 with PIC flags and disable `skia_use_system_freetype2`

### DIFF
--- a/skia_builder/config.py
+++ b/skia_builder/config.py
@@ -141,6 +141,7 @@ platform_specific_flags = {
     "linux-x64": {
         **linux_base_flags,
         "target_cpu": "x86_64",
+        "skia_use_system_freetype2": False,
         "extra_cflags": [
             *linux_base_flags["extra_cflags"],
             "-fPIC",


### PR DESCRIPTION
## Description

- Adds PIC flags and disables `skia_use_system_freetype2` for the linux-x64 target.

## Checklist

- [x] Code passes `ruff check .`
- [x] Code is formatted with `ruff format`
