### PR TITLE
Add `list-args` command to list available build arguments; list build arguments before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ skia-builder setup-env --sub-env=Android
 
 <br>
 
+### Listing available build arguments
+
+The `list-args` command displays all available build configuration arguments supported by the Skia version. These flags can be overridden using `--custom-build-args` or `--override-build-args`.
+
+```
+skia-builder list-args
+```
+
+
+<br>
+
 ### Generating Skia binaries
 
 To generate the binaries, **it is necessary to specify the target architecture**. Optionally, the `--archive` command can be used to archive the output binaries to `output/<OS>-<architecture>/*` and to generate a compressed file in `output/<OS><architecture>/<OS>-<architecture>.tar.gz`.

--- a/skia_builder/cli.py
+++ b/skia_builder/cli.py
@@ -55,6 +55,15 @@ def build(
     manager.build(target_cpu, custom_build_args, override_build_args, archive_build_output)
 
 
+def list_build_arguments(host_platform):
+    manager = PLATFORM_MANAGERS.get(host_platform)
+    if manager is None:
+        Logger.error(f"Unsupported target platform: {host_platform}")
+        sys.exit(1)
+
+    manager.list_build_arguments()
+
+
 def main():
     parser = argparse.ArgumentParser(prog="skia-builder", description="Skia Builder Script")
     subparsers = parser.add_subparsers(dest="command")
@@ -101,6 +110,10 @@ def main():
     )
     build_parser.set_defaults(func=build)
 
+    # list-args subcommand
+    list_args_parser = subparsers.add_parser("list-args", help="List available build arguments")
+    list_args_parser.set_defaults(func=list_build_arguments)
+
     args = parser.parse_args()
     current_platform = "macOS" if platform.system() == "Darwin" else platform.system()
 
@@ -138,6 +151,9 @@ def main():
             args.archive,
             args.sub_env,
         )
+
+    elif args.command == "list-args":
+        list_build_arguments(current_platform)
 
     else:
         Logger.error(f"Unsupported command: {args.command}")

--- a/skia_builder/platforms/common.py
+++ b/skia_builder/platforms/common.py
@@ -348,6 +348,39 @@ class CommonPlatformManager:
             archive_output,
         )
 
+    @classmethod
+    def list_build_arguments(cls):
+        """List available build arguments by creating a temporary build configuration."""
+        if not cls.TARGET_PLATFORM:
+            Logger.error("Unsupported target platform")
+            sys.exit(1)
+
+        skia_path = os.path.join(os.getcwd(), "skia")
+        dummy_dir = os.path.join(skia_path, "out", "dummy")
+
+        gn_executable = cls._get_executable_path(
+            "skia",
+            "bin",
+            executable_name="gn",
+            windows_extension=".exe",
+        )
+
+        run_command(
+            [gn_executable, "gen", "out/dummy"],
+            "Generating dummy build files",
+            cwd=skia_path,
+        )
+
+        run_command(
+            [gn_executable, "args", "--list", "out/dummy"],
+            "Listing available build arguments",
+            cwd=skia_path,
+        )
+
+        if os.path.exists(dummy_dir):
+            shutil.rmtree(dummy_dir)
+            Logger.info("Cleaned up temporary dummy directory")
+
 
 class CommonSubPlatformManager(CommonPlatformManager):
     HOST_PLATFORMS_ENV_SETUP = {}

--- a/skia_builder/platforms/common.py
+++ b/skia_builder/platforms/common.py
@@ -280,6 +280,17 @@ class CommonPlatformManager:
 
         run_command(
             [
+                gn_executable,
+                "args",
+                "--list",
+                f"out/{build_target}",
+            ],
+            f"Listing current build arguments for {build_target}",
+            cwd=skia_path,
+        )
+
+        run_command(
+            [
                 ninja_executable,
                 "-C",
                 f"out/{build_target}",


### PR DESCRIPTION
## Description
This PR adds a new `list-args` command that allows to view all available build configuration arguments supported by the current Skia version.

Listing the build arguments before compiling helps monitor the process and makes it easier to detect build errors caused by invalid or deprecated flags — for example, the removal of `skia_enable_gpu` in the transition from milestone M139 to M140.


## Checklist

- [x] Code passes `ruff check .`
- [x] Code is formatted with `ruff format`
